### PR TITLE
Assign ENVs to a child a process via exec command

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -45,15 +45,6 @@ Navigate to a project that contains one or many `.env` files, then type:
 nvi <flag> <arg>
 ```
 
-Example of parsing an `example.env` file from a custom directory with debug logging:
-```DOSINI
-nvi --files example.env --dir dist/client --debug
-```
-
-Example parsing one or many `.env` files from a [env.config.json](https://github.com/mattcarlotta/nvi/blob/main/env.config.json#L6-L11) configuration file located at a project's root directory:
-```DOSINI
-nvi -c bin_test_only
-```
 
 ## Binary Flags
 All flags below are optional. Short form (`-`) and long form (`--`) flags are supported and can be mixed if desired.
@@ -65,11 +56,29 @@ If no flags are assigned, then an `.env` (that is named ".env") located at the r
 | -c, --config    | Specifies which environment configuration to load from the env.config.json file. (ex: --config dev)‡  |
 | -de, --debug    | Specifies whether or not to log debug details. (ex: --debug)                                          |
 | -d, --dir       | Specifies which directory the env file is located within. (ex: --dir path/to/env)                     |
+| -e, --exec      | Specifies which command to run in a separate process with parsed ENVS. (ex: --exec node index.js)     |
 | -f, --files     | Specifies which .env files to parse separated by a space. (ex: --files test.env test2.env)            |
 | -r, --required  | Specifies which ENV keys are required separated by a space. (ex: --required KEY1 KEY2)                |
 | -h, --help      | Displays this help information.                                                                       |
 
-‡ When a "-c" or "--config" flag is present, then "debug", "dir", "files", and "required" flags are ignored as they should be defined within the "env.config.json" file.
+‡ When a "-c" or "--config" flag is present, then "debug", "dir", "exec", "files", and "required" flags are ignored as they should be defined within the "env.config.json" file.
+
+### Examples
+
+Example of parsing an `example.env` file from a custom directory with debug logging:
+```DOSINI
+nvi --files example.env --dir dist/client --debug
+```
+
+Example parsing one or many `.env` files from a [env.config.json](https://github.com/mattcarlotta/nvi/blob/main/env.config.json#L6-L11) configuration file located at a project's root directory:
+```DOSINI
+nvi --config bin_test_only
+```
+
+Example parsing an `.env` file, checking the parsed ENVs for required keys, and then, if good, applying those ENVs to a spawned "npm" child process:
+```DOSINI
+nvi --files .env --exec npm run dev --required KEY1 KEY2
+```
 
 
 ## FAQS

--- a/bin/src/arg.cpp
+++ b/bin/src/arg.cpp
@@ -75,7 +75,7 @@ string arg_parser::parse_single_arg(unsigned int code) {
     return arg;
 }
 
-vector<string> arg_parser::parse_multi_arg(unsigned int code, unsigned int expected_arg_length) {
+vector<string> arg_parser::parse_multi_arg(unsigned int code) {
     vector<string> arg;
     ++this->key;
     while (this->key < this->argc) {
@@ -93,7 +93,7 @@ vector<string> arg_parser::parse_multi_arg(unsigned int code, unsigned int expec
         ++this->key;
     }
 
-    if (!arg.size() || arg.size() < expected_arg_length) {
+    if (!arg.size()) {
         this->log(code);
         std::exit(1);
     }

--- a/bin/src/arg.cpp
+++ b/bin/src/arg.cpp
@@ -1,6 +1,7 @@
 #include "arg.h"
 #include "constants.h"
 #include "format.h"
+#include <cstring>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -224,10 +225,18 @@ void arg_parser::log(unsigned int code) const {
         break;
     }
     case constants::ARG_DEBUG: {
+        std::vector<std::string> _commands;
+        _commands.reserve(this->commands.size());
+
+        for (const char *cstr : this->commands) {
+            if (cstr != nullptr) {
+                _commands.emplace_back(cstr);
+            }
+        }
         std::clog << format("[nvi] (arg::DEBUG) The following flags were set: config=\"%s\", "
-                            "debug=\"true\", dir=\"%s\", files=\"%s\", required=\"%s\".",
-                            this->config.c_str(), this->dir.c_str(), join(this->files, ", ").c_str(),
-                            join(this->required_envs, ", ").c_str())
+                            "debug=\"true\", dir=\"%s\", execute=\"%s\", files=\"%s\", required=\"%s\".",
+                            this->config.c_str(), this->dir.c_str(), join(_commands, " ").c_str(),
+                            join(this->files, ", ").c_str(), join(this->required_envs, ", ").c_str())
                   << std::endl;
 
         if (this->config.length() && (this->dir.length() || this->files.size() > 1 || this->required_envs.size())) {

--- a/bin/src/arg.cpp
+++ b/bin/src/arg.cpp
@@ -114,7 +114,7 @@ void arg_parser::parse_command_args() {
             break;
         } else if (!this->commands.size()) {
             this->bin_name = next_arg;
-            next_arg = this->find_binary_path(next_arg);
+            // next_arg = this->find_binary_path(next_arg);
         }
 
         char *arg_str = new char[next_arg.size() + 1];
@@ -132,33 +132,33 @@ void arg_parser::parse_command_args() {
     this->commands.push_back(nullptr);
 }
 
-string arg_parser::find_binary_path(const string &bin) {
-    FILE *pipe = popen(("which " + bin).c_str(), "r");
-    if (!pipe) {
-        this->log(constants::ARG_COMMAND_WHICH_NOT_FOUND_ERROR);
-        std::exit(1);
-    }
+// string arg_parser::find_binary_path(const string &bin) {
+//     FILE *pipe = popen(("which " + bin).c_str(), "r");
+//     if (!pipe) {
+//         this->log(constants::ARG_COMMAND_WHICH_NOT_FOUND_ERROR);
+//         std::exit(1);
+//     }
 
-    char buffer[256];
-    string result = "";
+//     char buffer[256];
+//     string result = "";
 
-    while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
-        result += buffer;
-    }
+//     while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+//         result += buffer;
+//     }
 
-    pclose(pipe);
+//     pclose(pipe);
 
-    if (result.empty()) {
-        this->log(constants::ARG_COMMAND_BIN_NOT_FOUND_ERROR);
-        std::exit(1);
-    }
+//     if (result.empty()) {
+//         this->log(constants::ARG_COMMAND_BIN_NOT_FOUND_ERROR);
+//         std::exit(1);
+//     }
 
-    if (result[result.length() - 1] == constants::LINE_DELIMITER) {
-        result.erase(result.length() - 1);
-    }
+//     if (result[result.length() - 1] == constants::LINE_DELIMITER) {
+//         result.erase(result.length() - 1);
+//     }
 
-    return result;
-}
+//     return result;
+// }
 
 void arg_parser::log(unsigned int code) const {
     switch (code) {

--- a/bin/src/arg.h
+++ b/bin/src/arg.h
@@ -31,11 +31,6 @@ class arg_parser {
     string invalid_arg;
     string invalid_args;
     arg_parser(int &argc, char *argv[]);
-    ~arg_parser() {
-        for (char *cstr : this->commands) {
-            delete[] cstr;
-        }
-    }
 };
 } // namespace nvi
 

--- a/bin/src/arg.h
+++ b/bin/src/arg.h
@@ -16,11 +16,15 @@ class arg_parser {
     char **argv;
     void log(unsigned int code) const;
     string parse_single_arg(unsigned int code);
-    vector<string> parse_multi_arg(unsigned int code);
+    vector<string> parse_multi_arg(unsigned int code, unsigned int expected_arg_length = 1);
+    void set_binary_path();
 
     public:
     string config;
     bool debug = false;
+    vector<string> command;
+    vector<char *> commands;
+    string bin_path;
     string dir;
     vector<string> files = vector<string>{".env"};
     vector<string> required_envs;

--- a/bin/src/arg.h
+++ b/bin/src/arg.h
@@ -25,13 +25,17 @@ class arg_parser {
     string config;
     bool debug = false;
     vector<char *> commands;
-    string bin_path;
     string dir;
     vector<string> files = vector<string>{".env"};
     vector<string> required_envs;
     string invalid_arg;
     string invalid_args;
     arg_parser(int &argc, char *argv[]);
+    ~arg_parser() {
+        for (char *cstr : this->commands) {
+            delete[] cstr;
+        }
+    }
 };
 } // namespace nvi
 

--- a/bin/src/arg.h
+++ b/bin/src/arg.h
@@ -17,7 +17,7 @@ class arg_parser {
     char **argv;
     void log(unsigned int code) const;
     string parse_single_arg(unsigned int code);
-    vector<string> parse_multi_arg(unsigned int code, unsigned int expected_arg_length = 1);
+    vector<string> parse_multi_arg(unsigned int code);
     void parse_command_args();
     string find_binary_path(const string &bin);
 

--- a/bin/src/arg.h
+++ b/bin/src/arg.h
@@ -11,18 +11,19 @@ using std::vector;
 namespace nvi {
 class arg_parser {
     private:
-    unsigned int key;
+    size_t key;
     int argc;
+    string bin_name;
     char **argv;
     void log(unsigned int code) const;
     string parse_single_arg(unsigned int code);
     vector<string> parse_multi_arg(unsigned int code, unsigned int expected_arg_length = 1);
-    void set_binary_path();
+    void parse_command_args();
+    string find_binary_path(const string &bin);
 
     public:
     string config;
     bool debug = false;
-    vector<string> command;
     vector<char *> commands;
     string bin_path;
     string dir;

--- a/bin/src/arg.h
+++ b/bin/src/arg.h
@@ -24,6 +24,7 @@ class arg_parser {
     public:
     string config;
     bool debug = false;
+    string command;
     vector<char *> commands;
     string dir;
     vector<string> files = vector<string>{".env"};

--- a/bin/src/config.cpp
+++ b/bin/src/config.cpp
@@ -2,8 +2,10 @@
 #include "constants.h"
 #include "format.h"
 #include "json.cpp"
+#include <cstring>
 #include <filesystem>
 #include <iostream>
+#include <sstream>
 #include <string>
 
 using std::string;
@@ -44,27 +46,19 @@ config::config(const string *environment, const string env_dir) : env(environmen
         this->required_envs = this->env_config.at("required");
     }
 
-    // TODO: Parse string command to vector<char *>
-    // if (this->env_config.count("command")) {
-    // size_t start = 0;
-    // size_t end = input.find('\0');
+    if (this->env_config.count("execute")) {
+        this->command = this->env_config.at("execute");
+        std::istringstream command_iss(this->command);
+        std::string arg;
 
-    // while (end != std::string::npos) {
-    //     token = input.substr(start, end - start);
-    //     char* cstr = new char[token.length() + 1];
-    //     std::strcpy(cstr, token.c_str());
-    //     tokens.push_back(cstr);
+        while (command_iss >> arg) {
+            char *arg_cstr = new char[arg.length() + 1];
+            std::strcpy(arg_cstr, arg.c_str());
+            this->commands.push_back(arg_cstr);
+        }
 
-    //     start = end + 1;
-    //     end = input.find(delimiter, start);
-    // }
-
-    // token = input.substr(start, end);
-    // char* cstr = new char[token.length() + 1];
-    // std::strcpy(cstr, token.c_str());
-    // tokens.push_back(cstr);
-    //     this->required_envs = this->env_config.at("required");
-    // }
+        this->commands.push_back(nullptr);
+    }
 
     if (this->debug) {
         this->log(constants::CONFIG_DEBUG);
@@ -96,15 +90,15 @@ void config::log(unsigned int code) const {
             keys += el.key() + comma;
         }
 
-        std::clog
-            << format("[nvi] (config::DEBUG) Parsed the following keys \"%s\" from the env.config.json configuration "
-                      "file and selected the \"%s\" configuration.",
-                      keys.c_str(), &*this->env->c_str())
-            << std::endl;
+        std::clog << format("[nvi] (config::DEBUG) Parsed the following keys from the env.config.json configuration "
+                            "file: \"%s\" and selected the \"%s\" configuration.",
+                            keys.c_str(), &*this->env->c_str())
+                  << std::endl;
 
         std::clog << format("[nvi] (config::DEBUG) The following flags were set: "
-                            "debug=\"true\", dir=\"%s\", files=\"%s\", required=\"%s\".\n",
-                            this->dir.c_str(), join(this->files, ", ").c_str(), join(this->required_envs, ", ").c_str())
+                            "debug=\"true\", dir=\"%s\", execute=\"%s\", files=\"%s\", required=\"%s\".\n",
+                            this->dir.c_str(), this->command.c_str(), join(this->files, ", ").c_str(),
+                            join(this->required_envs, ", ").c_str())
                   << std::endl;
         break;
     }

--- a/bin/src/config.cpp
+++ b/bin/src/config.cpp
@@ -44,6 +44,28 @@ config::config(const string *environment, const string env_dir) : env(environmen
         this->required_envs = this->env_config.at("required");
     }
 
+    // TODO: Parse string command to vector<char *>
+    // if (this->env_config.count("command")) {
+    // size_t start = 0;
+    // size_t end = input.find('\0');
+
+    // while (end != std::string::npos) {
+    //     token = input.substr(start, end - start);
+    //     char* cstr = new char[token.length() + 1];
+    //     std::strcpy(cstr, token.c_str());
+    //     tokens.push_back(cstr);
+
+    //     start = end + 1;
+    //     end = input.find(delimiter, start);
+    // }
+
+    // token = input.substr(start, end);
+    // char* cstr = new char[token.length() + 1];
+    // std::strcpy(cstr, token.c_str());
+    // tokens.push_back(cstr);
+    //     this->required_envs = this->env_config.at("required");
+    // }
+
     if (this->debug) {
         this->log(constants::CONFIG_DEBUG);
     }

--- a/bin/src/config.h
+++ b/bin/src/config.h
@@ -23,15 +23,9 @@ class config {
     string dir;
     vector<string> files;
     vector<string> required_envs = vector<string>();
+    string command;
     vector<char *> commands;
     config(const string *environment, const string env_dir = "");
-    ~config() {
-        // if (this->commands.size()) {
-        for (char *cstr : this->commands) {
-            delete[] cstr;
-        }
-        // }
-    }
 };
 }; // namespace nvi
 

--- a/bin/src/config.h
+++ b/bin/src/config.h
@@ -23,7 +23,15 @@ class config {
     string dir;
     vector<string> files;
     vector<string> required_envs = vector<string>();
+    vector<char *> commands;
     config(const string *environment, const string env_dir = "");
+    ~config() {
+        // if (this->commands.size()) {
+        for (char *cstr : this->commands) {
+            delete[] cstr;
+        }
+        // }
+    }
 };
 }; // namespace nvi
 

--- a/bin/src/constants.h
+++ b/bin/src/constants.h
@@ -15,6 +15,8 @@ constexpr unsigned int ARG_INVALID_FLAG_WARNING = 6;
 constexpr unsigned int ARG_EXCEPTION = 7;
 constexpr unsigned int ARG_DEBUG = 8;
 constexpr unsigned int ARG_NO_PARSEABLE_ENVS = 9;
+constexpr unsigned int ARG_COMMAND_WHICH_NOT_FOUND_ERROR = 10;
+constexpr unsigned int ARG_COMMAND_BIN_NOT_FOUND_ERROR = 11;
 
 // config
 constexpr unsigned int CONFIG_FILE_ERROR = 0;

--- a/bin/src/constants.h
+++ b/bin/src/constants.h
@@ -7,13 +7,14 @@ namespace constants {
 // arg
 constexpr unsigned int ARG_CONFIG_FLAG_ERROR = 0;
 constexpr unsigned int ARG_DIR_FLAG_ERROR = 1;
-constexpr unsigned int ARG_FILES_FLAG_ERROR = 2;
-constexpr unsigned int ARG_REQUIRED_FLAG_ERROR = 3;
-constexpr unsigned int ARG_HELP_DOC = 4;
-constexpr unsigned int ARG_INVALID_FLAG_WARNING = 5;
-constexpr unsigned int ARG_EXCEPTION = 6;
-constexpr unsigned int ARG_DEBUG = 7;
-constexpr unsigned int ARG_NO_PARSEABLE_ENVS = 8;
+constexpr unsigned int ARG_COMMAND_FLAG_ERROR = 2;
+constexpr unsigned int ARG_FILES_FLAG_ERROR = 3;
+constexpr unsigned int ARG_REQUIRED_FLAG_ERROR = 4;
+constexpr unsigned int ARG_HELP_DOC = 5;
+constexpr unsigned int ARG_INVALID_FLAG_WARNING = 6;
+constexpr unsigned int ARG_EXCEPTION = 7;
+constexpr unsigned int ARG_DEBUG = 8;
+constexpr unsigned int ARG_NO_PARSEABLE_ENVS = 9;
 
 // config
 constexpr unsigned int CONFIG_FILE_ERROR = 0;

--- a/bin/src/constants.h
+++ b/bin/src/constants.h
@@ -15,8 +15,6 @@ constexpr unsigned int ARG_INVALID_FLAG_WARNING = 6;
 constexpr unsigned int ARG_EXCEPTION = 7;
 constexpr unsigned int ARG_DEBUG = 8;
 constexpr unsigned int ARG_NO_PARSEABLE_ENVS = 9;
-constexpr unsigned int ARG_COMMAND_WHICH_NOT_FOUND_ERROR = 10;
-constexpr unsigned int ARG_COMMAND_BIN_NOT_FOUND_ERROR = 11;
 
 // config
 constexpr unsigned int CONFIG_FILE_ERROR = 0;

--- a/bin/src/main.cpp
+++ b/bin/src/main.cpp
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <optional>
 #include <string>
-#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <vector>
@@ -36,7 +35,7 @@ int main(int argc, char *argv[]) {
         pid_t pid = fork();
 
         if (pid == 0) {
-            execvpe(arg.commands[0], &arg.commands[0], parser.get_envs());
+            execve(arg.commands[0], &arg.commands[0], parser.get_envs());
         } else if (pid > 0) {
             int status;
             wait(&status);

--- a/bin/src/main.cpp
+++ b/bin/src/main.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[]) {
 
     nvi::parser parser(&files, dir, &required_envs, debug);
 
-    parser.parse_envs();
+    parser.parse_envs()->check_envs();
 
     if (arg.commands.size()) {
         pid_t pid = fork();

--- a/bin/src/main.cpp
+++ b/bin/src/main.cpp
@@ -35,7 +35,9 @@ int main(int argc, char *argv[]) {
         pid_t pid = fork();
 
         if (pid == 0) {
-            execve(arg.commands[0], &arg.commands[0], parser.get_envs());
+            parser.set_envs();
+
+            execvp(arg.commands[0], arg.commands.data());
         } else if (pid > 0) {
             int status;
             wait(&status);

--- a/bin/src/main.cpp
+++ b/bin/src/main.cpp
@@ -2,12 +2,67 @@
 #include "config.h"
 #include "json.cpp"
 #include "parser.h"
+#include <cstring>
+#include <iostream>
 #include <optional>
 #include <string>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 #include <vector>
 
 using std::string;
 using std::vector;
+
+std::string findBinaryPath(const std::string &binaryName) {
+    std::string command = "which " + binaryName;
+
+    FILE *pipe = popen(command.c_str(), "r");
+    if (!pipe) {
+        std::cerr << "Failed to execute the 'which' command." << std::endl;
+        return "";
+    }
+
+    char buffer[128];
+    std::string result = "";
+
+    while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
+        result += buffer;
+    }
+
+    pclose(pipe);
+
+    // Remove trailing newline character if present
+    if (!result.empty() && result[result.length() - 1] == '\n') {
+        result.erase(result.length() - 1);
+    }
+
+    return result;
+}
+
+char **convertToCharArray(const std::map<std::string, std::string> &map) {
+    char **charArray = new char *[map.size() + 1]; // +1 for the null terminator
+
+    size_t index = 0;
+    for (const auto &[key, value] : map) {
+        const std::string entry = key + "=" + value;
+        charArray[index] = new char[entry.size() + 1]; // +1 for the null terminator
+        std::strcpy(charArray[index], entry.c_str());
+
+        ++index;
+    }
+
+    charArray[map.size()] = nullptr; // Add null terminator
+
+    return charArray;
+}
+
+void freeCharArray(char **charArray, size_t size) {
+    for (size_t i = 0; i < size; ++i) {
+        delete[] charArray[i];
+    }
+    delete[] charArray;
+}
 
 int main(int argc, char *argv[]) {
     nvi::arg_parser arg(argc, argv);
@@ -25,6 +80,24 @@ int main(int argc, char *argv[]) {
     }
 
     nvi::parser parser(&files, dir, &required_envs, debug);
+    std::string binaryPath = findBinaryPath("npm");
 
-    return parser.parse_envs()->print_envs();
+    auto envs = parser.parse_envs()->env_map;
+    char **charArray = convertToCharArray(envs);
+    pid_t pid = fork();
+
+    if (pid == 0) {
+        // Child process
+        execle(binaryPath.c_str(), "npm", "run", "dev", NULL, charArray);
+        freeCharArray(charArray, envs.size() + 1);
+    } else if (pid > 0) {
+        // Parent process
+        int status;
+        wait(&status);
+    } else {
+        // Error occurred
+        // Handle the error here
+    }
+
+    return 0;
 }

--- a/bin/src/main.cpp
+++ b/bin/src/main.cpp
@@ -35,6 +35,10 @@ int main(int argc, char *argv[]) {
         pid_t pid = fork();
 
         if (pid == 0) {
+            // NOTE: Unfortunately, have to set ENVs to the parent process because
+            // "execvpe" doesn't exist on POSIX and "execle" doesn't allow binaries
+            // that were called to locate other binaries found within shell "PATH"
+            // for example: "npm run dev" won't work because "npm" can't find "node"
             parser.set_envs();
 
             execvp(arg.commands[0], arg.commands.data());

--- a/bin/src/main.cpp
+++ b/bin/src/main.cpp
@@ -2,7 +2,6 @@
 #include "config.h"
 #include "json.cpp"
 #include "parser.h"
-#include <cstring>
 #include <iostream>
 #include <optional>
 #include <string>
@@ -13,56 +12,6 @@
 
 using std::string;
 using std::vector;
-
-std::string findBinaryPath(const std::string &binaryName) {
-    std::string command = "which " + binaryName;
-
-    FILE *pipe = popen(command.c_str(), "r");
-    if (!pipe) {
-        std::cerr << "Failed to execute the 'which' command." << std::endl;
-        return "";
-    }
-
-    char buffer[128];
-    std::string result = "";
-
-    while (fgets(buffer, sizeof(buffer), pipe) != nullptr) {
-        result += buffer;
-    }
-
-    pclose(pipe);
-
-    // Remove trailing newline character if present
-    if (!result.empty() && result[result.length() - 1] == '\n') {
-        result.erase(result.length() - 1);
-    }
-
-    return result;
-}
-
-char **convertToCharArray(const std::map<std::string, std::string> &map) {
-    char **charArray = new char *[map.size() + 1]; // +1 for the null terminator
-
-    size_t index = 0;
-    for (const auto &[key, value] : map) {
-        const std::string entry = key + "=" + value;
-        charArray[index] = new char[entry.size() + 1]; // +1 for the null terminator
-        std::strcpy(charArray[index], entry.c_str());
-
-        ++index;
-    }
-
-    charArray[map.size()] = nullptr; // Add null terminator
-
-    return charArray;
-}
-
-void freeCharArray(char **charArray, size_t size) {
-    for (size_t i = 0; i < size; ++i) {
-        delete[] charArray[i];
-    }
-    delete[] charArray;
-}
 
 int main(int argc, char *argv[]) {
     nvi::arg_parser arg(argc, argv);
@@ -80,24 +29,23 @@ int main(int argc, char *argv[]) {
     }
 
     nvi::parser parser(&files, dir, &required_envs, debug);
-    std::string binaryPath = findBinaryPath("npm");
 
-    auto envs = parser.parse_envs()->env_map;
-    char **charArray = convertToCharArray(envs);
-    pid_t pid = fork();
+    parser.parse_envs();
 
-    if (pid == 0) {
-        // Child process
-        execle(binaryPath.c_str(), "npm", "run", "dev", NULL, charArray);
-        freeCharArray(charArray, envs.size() + 1);
-    } else if (pid > 0) {
-        // Parent process
-        int status;
-        wait(&status);
+    if (arg.commands.size()) {
+        pid_t pid = fork();
+
+        if (pid == 0) {
+            execvpe(arg.commands[0], &arg.commands[0], parser.get_envs());
+        } else if (pid > 0) {
+            int status;
+            wait(&status);
+        } else {
+            std::cerr << "[nvi] (main::COMMAND_FAILED_TO_START) Unable to run the specified command." << std::endl;
+            std::exit(1);
+        }
     } else {
-        // Error occurred
-        // Handle the error here
+        parser.print_envs();
     }
-
     return 0;
 }

--- a/bin/src/parser.cpp
+++ b/bin/src/parser.cpp
@@ -122,21 +122,10 @@ void parser::check_envs() {
     }
 }
 
-char **parser::get_envs() {
-    this->env_array = new char *[this->env_map.size() + 1];
-
-    size_t index = 0;
+void parser::set_envs() {
     for (const auto &[key, value] : this->env_map) {
-        const std::string entry = key + "=" + value;
-        this->env_array[index] = new char[entry.size() + 1];
-        std::strcpy(this->env_array[index], entry.c_str());
-
-        ++index;
+        setenv(key.c_str(), value.c_str(), 0);
     }
-
-    this->env_array[this->env_map.size()] = nullptr;
-
-    return this->env_array;
 }
 
 void parser::print_envs() {

--- a/bin/src/parser.cpp
+++ b/bin/src/parser.cpp
@@ -46,10 +46,6 @@ parser *parser::parse() {
                     continue;
                 }
 
-                // if (current_char == constants::DOUBLE_QUOTE) {
-                //     this->value += constants::BACK_SLASH;
-                // }
-
                 if (current_char == constants::DOLLAR_SIGN && next_char == constants::OPEN_BRACE) {
                     const string val_slice_str = line_slice.substr(this->val_byte_count, line_slice.length());
 
@@ -132,9 +128,19 @@ void parser::print_envs() {
     const string last_key = std::prev(this->env_map.end())->first;
     std::cout << "{" << std::endl;
     for (auto const &[key, value] : this->env_map) {
+        string esc_value;
+        size_t i = 0;
+        while (i < value.size()) {
+            char current_char = value[i];
+            if (current_char == constants::DOUBLE_QUOTE) {
+                esc_value += constants::BACK_SLASH;
+            }
+            esc_value += current_char;
+            ++i;
+        }
         const string comma = key != last_key ? "," : "";
         std::cout << std::setw(4) << "\"" << key << "\""
-                  << ": \"" << value << "\"" << comma << std::endl;
+                  << ": \"" << esc_value << "\"" << comma << std::endl;
     }
     std::cout << "}" << std::endl;
 }

--- a/bin/src/parser.cpp
+++ b/bin/src/parser.cpp
@@ -102,7 +102,7 @@ parser *parser::parse() {
     return this;
 }
 
-int parser::print_envs() {
+void parser::check_envs() {
     if (this->required_envs != nullptr && this->required_envs->size()) {
         for (const string key : *this->required_envs) {
             if (!this->env_map.count(key) || !this->env_map.at(key).length()) {
@@ -120,7 +120,26 @@ int parser::print_envs() {
         this->log(constants::PARSER_EMPTY_ENVS);
         std::exit(1);
     }
+}
 
+char **parser::get_envs() {
+    this->env_array = new char *[this->env_map.size() + 1];
+
+    size_t index = 0;
+    for (const auto &[key, value] : this->env_map) {
+        const std::string entry = key + "=" + value;
+        this->env_array[index] = new char[entry.size() + 1];
+        std::strcpy(this->env_array[index], entry.c_str());
+
+        ++index;
+    }
+
+    this->env_array[this->env_map.size()] = nullptr;
+
+    return this->env_array;
+}
+
+void parser::print_envs() {
     const string last_key = std::prev(this->env_map.end())->first;
     std::cout << "{" << std::endl;
     for (auto const &[key, value] : this->env_map) {
@@ -129,8 +148,6 @@ int parser::print_envs() {
                   << ": \"" << value << "\"" << comma << std::endl;
     }
     std::cout << "}" << std::endl;
-
-    return 0;
 }
 
 parser *parser::read(const string &env_file_name) {

--- a/bin/src/parser.cpp
+++ b/bin/src/parser.cpp
@@ -46,9 +46,9 @@ parser *parser::parse() {
                     continue;
                 }
 
-                if (current_char == constants::DOUBLE_QUOTE) {
-                    this->value += constants::BACK_SLASH;
-                }
+                // if (current_char == constants::DOUBLE_QUOTE) {
+                //     this->value += constants::BACK_SLASH;
+                // }
 
                 if (current_char == constants::DOLLAR_SIGN && next_char == constants::OPEN_BRACE) {
                     const string val_slice_str = line_slice.substr(this->val_byte_count, line_slice.length());

--- a/bin/src/parser.h
+++ b/bin/src/parser.h
@@ -32,7 +32,6 @@ class parser {
     string key_prop;
     string value;
     vector<string> undefined_keys;
-    char **env_array = nullptr;
     void log(unsigned int code) const;
     parser *read(const string &env_file_name);
     parser *parse();
@@ -41,17 +40,9 @@ class parser {
     std::map<string, string> env_map;
     parser(const vector<string> *files, const std::optional<string> &dir, const vector<string> *required_envs = nullptr,
            const bool &debug = false);
-    ~parser() {
-        if (this->env_array != nullptr) {
-            for (size_t i = 0; i < this->env_map.size(); ++i) {
-                delete[] this->env_array[i];
-            }
-            delete[] this->env_array;
-        }
-    }
     void check_envs();
     parser *parse_envs() noexcept;
-    char **get_envs();
+    void set_envs();
     void print_envs();
 };
 }; // namespace nvi

--- a/bin/src/parser.h
+++ b/bin/src/parser.h
@@ -23,10 +23,10 @@ class parser {
     string loaded_file;
     string file_name;
     string file_path;
-    unsigned int file_length;
-    unsigned int byte_count;
-    unsigned int line_count;
-    unsigned int val_byte_count;
+    size_t file_length;
+    size_t byte_count;
+    size_t line_count;
+    size_t val_byte_count;
     int assignment_index;
     string key;
     string key_prop;

--- a/bin/src/parser.h
+++ b/bin/src/parser.h
@@ -32,6 +32,7 @@ class parser {
     string key_prop;
     string value;
     vector<string> undefined_keys;
+    char **env_array = nullptr;
     void log(unsigned int code) const;
     parser *read(const string &env_file_name);
     parser *parse();
@@ -40,8 +41,18 @@ class parser {
     std::map<string, string> env_map;
     parser(const vector<string> *files, const std::optional<string> &dir, const vector<string> *required_envs = nullptr,
            const bool &debug = false);
+    ~parser() {
+        if (this->env_array != nullptr) {
+            for (size_t i = 0; i < this->env_map.size(); ++i) {
+                delete[] this->env_array[i];
+            }
+            delete[] this->env_array;
+        }
+    }
+    void check_envs();
     parser *parse_envs() noexcept;
-    int print_envs();
+    char **get_envs();
+    void print_envs();
 };
 }; // namespace nvi
 

--- a/bin/tests/test-arg.cpp
+++ b/bin/tests/test-arg.cpp
@@ -3,10 +3,10 @@
 #include <string>
 #include <vector>
 
-char *argv[] = {(char *)"",          (char *)"--config",   (char *)"test",    (char *)"--debug",
-                (char *)"--dir",     (char *)"tests",      (char *)"--files", (char *)"test.env",
-                (char *)"test2.env", (char *)"--required", (char *)"KEY1",    (char *)"KEY2"};
-int argc = 12;
+char *argv[] = {(char *)"",         (char *)"--config",  (char *)"test",       (char *)"--debug", (char *)"--exec",
+                (char *)"bin",      (char *)"test",      (char *)"--dir",      (char *)"tests",   (char *)"--files",
+                (char *)"test.env", (char *)"test2.env", (char *)"--required", (char *)"KEY1",    (char *)"KEY2"};
+int argc = 15;
 
 nvi::arg_parser arg(argc, argv);
 
@@ -15,6 +15,8 @@ TEST(arg_parser, parseable_config) { EXPECT_EQ(arg.config, "test"); }
 TEST(arg_parser, parseable_debug) { EXPECT_EQ(arg.debug, true); }
 
 TEST(arg_parser, parseable_directory) { EXPECT_EQ(arg.dir, "tests"); }
+
+TEST(arg_parser, parseable_execute) { EXPECT_EQ(arg.commands.size(), 3); }
 
 TEST(arg_parser, parseable_files) {
     const std::vector<std::string> files = {"test.env", "test2.env"};

--- a/bin/tests/test-config.cpp
+++ b/bin/tests/test-config.cpp
@@ -14,6 +14,8 @@ TEST(parse_config_file, debug) { EXPECT_EQ(config.debug, true); }
 
 TEST(parse_config_file, directory) { EXPECT_EQ(config.dir, "custom/directory"); }
 
+TEST(parse_config_file, execute) { EXPECT_EQ(config.commands.size(), 3); }
+
 TEST(parse_config_file, files) {
     const vector<string> files = {"test1.env", "test2.env", "test3.env"};
     EXPECT_EQ(config.files, files);

--- a/bin/tests/test-parser.cpp
+++ b/bin/tests/test-parser.cpp
@@ -50,23 +50,21 @@ TEST_F(parse_env_file, empty_interp_key_values) { EXPECT_EQ(env_map.at("EMPTY_IN
 
 TEST_F(parse_env_file, single_quote_values) { EXPECT_EQ(env_map.at("SINGLE_QUOTES_SPACES"), "'  SINGLE QUOTES  '"); }
 
-TEST_F(parse_env_file, double_quote_values) {
-    EXPECT_EQ(env_map.at("DOUBLE_QUOTES_SPACES"), "\\\"  DOUBLE QUOTES  \\\"");
-}
+TEST_F(parse_env_file, double_quote_values) { EXPECT_EQ(env_map.at("DOUBLE_QUOTES_SPACES"), "\"  DOUBLE QUOTES  \""); }
 
-TEST_F(parse_env_file, quote_values) { EXPECT_EQ(env_map.at("QUOTES"), "sad\\\"wow\\\"bak"); }
+TEST_F(parse_env_file, quote_values) { EXPECT_EQ(env_map.at("QUOTES"), "sad\"wow\"bak"); }
 
 TEST_F(parse_env_file, invalid_single_quote_values) { EXPECT_EQ(env_map.at("INVALID_SINGLE_QUOTES"), "bad\'dq"); }
 
-TEST_F(parse_env_file, invalid_double_quote_values) { EXPECT_EQ(env_map.at("INVALID_DOUBLE_QUOTES"), "bad\\\"dq"); }
+TEST_F(parse_env_file, invalid_double_quote_values) { EXPECT_EQ(env_map.at("INVALID_DOUBLE_QUOTES"), "bad\"dq"); }
 
 TEST_F(parse_env_file, invalid_template_literal_values) { EXPECT_EQ(env_map.at("INVALID_TEMPLATE_LITERAL"), "bad`as"); }
 
-TEST_F(parse_env_file, invalid_mix_quotes_values) { EXPECT_EQ(env_map.at("INVALID_MIX_QUOTES"), "bad\\\"'`mq"); }
+TEST_F(parse_env_file, invalid_mix_quotes_values) { EXPECT_EQ(env_map.at("INVALID_MIX_QUOTES"), "bad\"'`mq"); }
 
 TEST_F(parse_env_file, empty_single_quotes_values) { EXPECT_EQ(env_map.at("EMPTY_SINGLE_QUOTES"), "''"); }
 
-TEST_F(parse_env_file, empty_double_quotes_values) { EXPECT_EQ(env_map.at("EMPTY_DOUBLE_QUOTES"), "\\\"\\\""); }
+TEST_F(parse_env_file, empty_double_quotes_values) { EXPECT_EQ(env_map.at("EMPTY_DOUBLE_QUOTES"), "\"\""); }
 
 TEST_F(parse_env_file, empty_template_literal_values) { EXPECT_EQ(env_map.at("EMPTY_TEMPLATE_LITERAL"), "``"); }
 

--- a/env.config.json
+++ b/env.config.json
@@ -6,6 +6,7 @@
     "bin_test_only": {
         "debug": true,
         "dir": "custom/directory",
+        "execute": "bin test",
         "files": ["test1.env", "test2.env", "test3.env"],
         "required": ["TEST1", "TEST2", "TEST3"]
     },
@@ -14,6 +15,11 @@
         "dir": "tests/envs",
         "files": [".env"],
         "required": ["BASIC_ENV", "MESSAGE", "MULTI_LINE_KEY", "MONGOLAB_URI"]
+    },
+    "exe": {
+        "debug": true,
+        "execute": "npm run dev",
+        "files": [".env"]
     },
     "error": {
         "debug": true,

--- a/env.config.json
+++ b/env.config.json
@@ -16,9 +16,10 @@
         "files": [".env"],
         "required": ["BASIC_ENV", "MESSAGE", "MULTI_LINE_KEY", "MONGOLAB_URI"]
     },
-    "exe": {
+    "exec": {
         "debug": true,
-        "execute": "npm run dev",
+        "dir": "tests/envs",
+        "execute": "node ./tests/exec.spec.mjs",
         "files": [".env"]
     },
     "error": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nvi",
     "version": "0.0.1",
-    "description": "Reading and assigning ENVs made blazingly fast.",
+    "description": "Reading and assigning ENVs to a process made blazingly fast.",
     "author": "Matt Carlotta",
     "license": "GPL 3.0",
     "main": "index.js",
@@ -57,7 +57,9 @@
         "test": "NODE_ENV=test DISABLE_LOG=true ts-node ./tests/index.ts",
         "test:logs": "NODE_ENV=test DISABLE_LOG=false ts-node ./tests/index.ts",
         "test:bin": "./bin/src/nvi --files bin.env --dir tests/envs | ts-node ./tests/bin.spec.ts",
-        "test:bin:config": "./bin/src/nvi --config bin | ts-node ./tests/bin.spec.ts"
+        "test:bin:config": "./bin/src/nvi --config bin | ts-node ./tests/bin.spec.ts",
+        "test:bin:config:exec": "./bin/src/nvi --config exec",
+        "test:bin:exec": "./bin/src/nvi --dir tests/envs --exec node ./tests/exec.spec.mjs"
     },
     "keywords": [
         "env",


### PR DESCRIPTION
- Add ability to assign ENVs to a child process
   - Add support for "exec" command via args or config
   - Add tests for "exec" command for args and config
   - Add README documentation for "exec" command
- Fall back to printing parsed ENVs to stdout if a "exec" command wasn't used
- Change parser's byte, line and assignment variable counters to `size_t` for very large files